### PR TITLE
Make Maven available in the build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
-FROM garethjevans/jenkinsslave:v1.1.5
+FROM garethjevans/jenkinsslave-maven:v1.3.5
 
 ENV NODE_FLAVOUR=6.x
+
+USER root
 
 RUN curl -sL https://deb.nodesource.com/setup_${NODE_FLAVOUR} | bash - && \
     apt-get -y install nodejs calibre && \
@@ -8,3 +10,5 @@ RUN curl -sL https://deb.nodesource.com/setup_${NODE_FLAVOUR} | bash - && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN npm install gitbook-cli -g
+
+USER jenkins


### PR DESCRIPTION
In order to support Maven driven builds, having Maven installed on the slave is necessary