### PR TITLE
Use 'gitbook --version' to complete gitbook installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,3 +16,5 @@ RUN curl -sL https://deb.nodesource.com/setup_${NODE_FLAVOUR} | bash - && \
 RUN npm install gitbook-cli -g
 
 USER jenkins
+
+RUN gitbook --version


### PR DESCRIPTION
When attempting to run a container based off this Docker image, gitbook hangs if the container has no Internet connection. Adding a call to gitbook --version at this stage means the Docker image will have all the gitbook stuff needed upfront.