### PR TITLE
Allow offline access to gitbook toc plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN curl -sL https://deb.nodesource.com/setup_${NODE_FLAVOUR} | bash - && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-RUN npm install gitbook-cli -g
+RUN npm install gitbook-cli gitbook-plugin-simple-page-toc -g
 
 USER jenkins
 


### PR DESCRIPTION
Added global install of the gitbook-plugin-simple-page-toc plugin
so that books can install this plugin when access to npm registry is
limited